### PR TITLE
Fix link position misalignment (indexOf + empty cell drift)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+out-test/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Create a [Link Provider](https://github.com/xtermjs/xterm.js/blob/a73fe62b7aedcd
 
 [![npm](https://img.shields.io/npm/v/xterm-link-provider?style=for-the-badge)](https://www.npmjs.com/package/xterm-link-provider)
 [![unpkg](https://img.shields.io/badge/dynamic/json?label=unpkg&query=$.version&url=https%3A%2F%2Funpkg.com%2Fxterm-link-provider%40latest%2Fpackage.json&style=for-the-badge&color=orange)](https://unpkg.com/xterm-link-provider@latest/)
+[![test](https://img.shields.io/github/actions/workflow/status/LabhanshAgrawal/xterm-link-provider/test.yml?style=for-the-badge&label=tests)](https://github.com/LabhanshAgrawal/xterm-link-provider/actions/workflows/test.yml)
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "./lib/esm/index.js",
   "types": "./lib/cjs/index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\"",
+    "test": "tsc -p tsconfig-test.json && mocha --ui tdd out-test/test/**/*.test.js",
     "compile": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
     "prepare": "yarn run compile",
     "demo": "python3 -m http.server 8080"
@@ -38,6 +38,9 @@
     "@xterm/xterm": "^6.0.0"
   },
   "devDependencies": {
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^25.5.0",
+    "mocha": "^11.7.5",
     "typescript": "^5.7.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "tsc -p tsconfig-test.json && mocha --ui tdd out-test/test/**/*.test.js",
     "compile": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
-    "prepare": "yarn run compile",
+    "prepare": "npm run compile",
     "demo": "python3 -m http.server 8080"
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,11 +142,16 @@ const stringIndexToBufferPosition = (
     const length = line.length;
     for (let i = 0; i < length; ) {
       line.getCell(i, cell);
-      stringIndex -= cell.getChars().length;
+      const charsLen = cell.getChars().length;
+      const cellWidth = cell.getWidth();
+      // Empty cells (from cursor moves like \e[1C) have no chars but
+      // occupy space. translateToString renders them as spaces, so they
+      // consume 1 string position even though getChars() returns "".
+      stringIndex -= charsLen > 0 ? charsLen : (cellWidth > 0 ? 1 : 0);
       if (stringIndex < 0) {
-        return {x: i + (reportLastCell ? cell.getWidth() : 1), y: lineIndex + 1};
+        return {x: i + (reportLastCell ? cellWidth : 1), y: lineIndex + 1};
       }
-      i += cell.getWidth();
+      i += cellWidth;
     }
     lineIndex++;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,11 +62,12 @@ export const computeLink = (y: number, regex: RegExp, terminal: Terminal, matchI
       break;
     }
 
-    // Get index, match.index is for the outer match which includes negated chars
-    // therefore we cannot use match.index directly, instead we search the position
-    // of the match group in text again
-    // also correct regex and string search offsets for the next loop run
-    stringIndex = line.indexOf(text, stringIndex + 1);
+    // Derive the capture group position from match.index.
+    // match.index is the start of match[0] (full match); the capture group
+    // (match[matchIndex]) is a substring within it. Using indexOf on the
+    // full match (not the whole line) avoids false hits when the same text
+    // appears earlier in the line.
+    stringIndex = match.index + match[0].indexOf(text);
     rex.lastIndex = stringIndex + text.length;
     if (stringIndex < 0) {
       // invalid stringIndex (should not have happened)

--- a/test/computeLink.test.ts
+++ b/test/computeLink.test.ts
@@ -39,6 +39,68 @@ function mockTerminal(lines: string[], cols = 200): Terminal {
   } as unknown as Terminal;
 }
 
+/**
+ * Advanced Terminal mock with explicit cell definitions.
+ * Simulates wide characters, empty cells (from cursor moves), etc.
+ */
+interface MockCell {
+  chars: string;
+  width: number;
+}
+
+function mockTerminalWithCells(linesCells: MockCell[][], cols = 200): Terminal {
+  return {
+    cols,
+    buffer: {
+      active: {
+        getLine(index: number) {
+          if (index < 0 || index >= linesCells.length) return undefined;
+          const cells = linesCells[index];
+          // translateToString: produce string as xterm.js would —
+          // each cell with width > 0 contributes chars or a space if empty
+          let str = '';
+          for (const c of cells) {
+            if (c.width === 0) continue; // skip wide char continuations
+            str += c.chars.length > 0 ? c.chars : ' ';
+          }
+          return {
+            isWrapped: false,
+            length: cells.length,
+            translateToString(_trim?: boolean) { return _trim ? str.trimEnd() : str; },
+            getCell(i: number, cell: any) {
+              if (i < cells.length) {
+                cell._char = cells[i].chars;
+                cell._width = cells[i].width;
+              } else {
+                cell._char = '';
+                cell._width = 0;
+              }
+              return cell;
+            },
+          };
+        },
+        getNullCell() {
+          return {
+            _char: '',
+            _width: 0,
+            getChars() { return this._char; },
+            getWidth() { return this._width; },
+          };
+        },
+      },
+    },
+  } as unknown as Terminal;
+}
+
+/** Helper: create a normal single-width cell */
+function ch(c: string): MockCell { return { chars: c, width: 1 }; }
+/** Helper: create a wide character (2 cells) */
+function wide(c: string): MockCell[] { return [{ chars: c, width: 2 }, { chars: '', width: 0 }]; }
+/** Helper: create an empty cell (from cursor movement like \e[1C]) */
+function empty(): MockCell { return { chars: '', width: 1 }; }
+/** Helper: convert a plain string to cells */
+function strCells(s: string): MockCell[] { return s.split('').map(ch); }
+
 suite('computeLink', () => {
   // Regex with a capture group (matchIndex=1), as typically used
   const LINK_REGEX = /(https?:\/\/[^\s"'`()\[\]{}]+|(?:~|\.\.?)?\/[^\s"'`()\[\]{}]*[^\s"'`()\[\]{}\/]|[a-zA-Z0-9_\-\.]+\/[a-zA-Z0-9_\-\.\/]*[a-zA-Z0-9_\-\.])/;
@@ -131,6 +193,62 @@ suite('computeLink', () => {
     assert.strictEqual(links.length, 1, `Expected 1 link but found ${links.length}: ${JSON.stringify(links.map(l => ({ text: l.text, x: l.range.start.x })))}`);
     assert.strictEqual(links[0].text, 'src/a.ts');
     assert.strictEqual(links[0].range.start.x, 25);
+  });
+
+  test('should handle wide characters before a path', () => {
+    // Simulates: ⏺ Update(src/terminal/ptyManager.ts)
+    // ⏺ is a wide char (2 cells), followed by an empty cell from \e[1C
+    // This is exactly what Claude Code outputs for file edits.
+    const cells: MockCell[] = [
+      ...wide('⏺'),           // cells 0-1: wide char
+      empty(),                 // cell 2: empty from cursor move
+      ...strCells('Update(src/terminal/ptyManager.ts)'),
+    ];
+    const term = mockTerminalWithCells([cells]);
+    const links = computeLink(1, LINK_REGEX, term);
+
+    assert.strictEqual(links.length, 1);
+    assert.strictEqual(links[0].text, 'src/terminal/ptyManager.ts');
+    // ⏺ takes 2 cells, empty takes 1, "Update(" is 7 chars at cells 3-9
+    // "src" starts at cell 10 → x=11 (1-based)
+    assert.strictEqual(links[0].range.start.x, 11);
+  });
+
+  test('should handle multiple wide characters and empty cells', () => {
+    // Two wide chars with empty cells: ⏺ ⎿ src/file.ts
+    const cells: MockCell[] = [
+      ...wide('⏺'),           // cells 0-1
+      empty(),                 // cell 2
+      ...wide('⎿'),           // cells 3-4
+      empty(),                 // cell 5
+      ...strCells('src/file.ts'),
+    ];
+    const term = mockTerminalWithCells([cells]);
+    const links = computeLink(1, LINK_REGEX, term);
+
+    assert.strictEqual(links.length, 1);
+    assert.strictEqual(links[0].text, 'src/file.ts');
+    // cells 0-1: ⏺, cell 2: empty, cells 3-4: ⎿, cell 5: empty
+    // "src" starts at cell 6 → x=7
+    assert.strictEqual(links[0].range.start.x, 7);
+  });
+
+  test('should correctly position link end with wide chars before it', () => {
+    // ⏺ src/a.ts
+    const cells: MockCell[] = [
+      ...wide('⏺'),
+      empty(),
+      ...strCells('src/a.ts'),
+    ];
+    const term = mockTerminalWithCells([cells]);
+    const links = computeLink(1, LINK_REGEX, term);
+
+    assert.strictEqual(links.length, 1);
+    assert.strictEqual(links[0].text, 'src/a.ts');
+    // "src/a.ts" is 8 chars, starts at cell 3 → x=4 start
+    // last char 's' at cell 10 → x = 10 + width(1) = 11
+    assert.strictEqual(links[0].range.start.x, 4);
+    assert.strictEqual(links[0].range.end.x, 11);
   });
 
   test('should verify link text matches line content at reported position', () => {

--- a/test/computeLink.test.ts
+++ b/test/computeLink.test.ts
@@ -1,0 +1,161 @@
+import * as assert from 'assert';
+import { computeLink } from '../src/index';
+import type { Terminal } from '@xterm/xterm';
+
+/**
+ * Minimal Terminal mock for computeLink tests.
+ * Simulates a terminal buffer with a single non-wrapped line.
+ */
+function mockTerminal(lines: string[], cols = 200): Terminal {
+  return {
+    cols,
+    buffer: {
+      active: {
+        getLine(index: number) {
+          if (index < 0 || index >= lines.length) return undefined;
+          const text = lines[index];
+          return {
+            isWrapped: false,
+            length: text.length,
+            translateToString(_trim?: boolean) { return text; },
+            getCell(i: number, cell: any) {
+              const ch = i < text.length ? text[i] : '';
+              cell._char = ch;
+              cell._width = ch ? 1 : 0;
+              return cell;
+            },
+          };
+        },
+        getNullCell() {
+          return {
+            _char: '',
+            _width: 0,
+            getChars() { return this._char; },
+            getWidth() { return this._width; },
+          };
+        },
+      },
+    },
+  } as unknown as Terminal;
+}
+
+suite('computeLink', () => {
+  // Regex with a capture group (matchIndex=1), as typically used
+  const LINK_REGEX = /(https?:\/\/[^\s"'`()\[\]{}]+|(?:~|\.\.?)?\/[^\s"'`()\[\]{}]*[^\s"'`()\[\]{}\/]|[a-zA-Z0-9_\-\.]+\/[a-zA-Z0-9_\-\.\/]*[a-zA-Z0-9_\-\.])/;
+
+  test('should find a simple relative path', () => {
+    const term = mockTerminal(['Look at src/webview/tabManager.ts for details']);
+    const links = computeLink(1, LINK_REGEX, term);
+    assert.strictEqual(links.length, 1);
+    assert.strictEqual(links[0].text, 'src/webview/tabManager.ts');
+    // Should start at the correct column (1-based)
+    assert.strictEqual(links[0].range.start.x, 9); // "Look at " = 8 chars, path starts at col 9
+  });
+
+  test('should find correct position when substring appears earlier in line', () => {
+    // "tabManager.ts" appears as a bare word before the full path.
+    // The bare word does NOT match the regex (no slash), but indexOf
+    // would find it first if searching the whole line.
+    const line = 'See tabManager.ts docs in src/webview/tabManager.ts for details';
+    const term = mockTerminal([line]);
+    const links = computeLink(1, LINK_REGEX, term);
+
+    assert.strictEqual(links.length, 1);
+    assert.strictEqual(links[0].text, 'src/webview/tabManager.ts');
+
+    // The link should point to "src/webview/tabManager.ts" at index 26
+    const expectedStart = line.indexOf('src/webview/tabManager.ts') + 1; // 1-based
+    assert.strictEqual(links[0].range.start.x, expectedStart);
+  });
+
+  test('should find correct positions for two paths where second contains first', () => {
+    const line = 'Compare utils/helper.ts with src/utils/helper.ts';
+    const term = mockTerminal([line]);
+    const links = computeLink(1, LINK_REGEX, term);
+
+    assert.strictEqual(links.length, 2);
+    assert.strictEqual(links[0].text, 'utils/helper.ts');
+    assert.strictEqual(links[1].text, 'src/utils/helper.ts');
+
+    // First path starts at "Compare " (8 chars) -> col 9
+    assert.strictEqual(links[0].range.start.x, 9);
+    // Second path starts at "Compare utils/helper.ts with " (29 chars) -> col 30
+    assert.strictEqual(links[1].range.start.x, 30);
+  });
+
+  test('should find multiple paths with shared substrings', () => {
+    const line = 'Modified src/utils/log.ts and src/utils/log.test.ts';
+    const term = mockTerminal([line]);
+    const links = computeLink(1, LINK_REGEX, term);
+
+    assert.strictEqual(links.length, 2);
+    assert.strictEqual(links[0].text, 'src/utils/log.ts');
+    assert.strictEqual(links[1].text, 'src/utils/log.test.ts');
+
+    assert.strictEqual(links[0].range.start.x, 10);
+    assert.strictEqual(links[1].range.start.x, 31);
+  });
+
+  test('should handle path preceded by non-matching text with same basename', () => {
+    // Regex with lookbehind-style prefix that creates match[0] != match[1]
+    // Using a regex where the capture group is a subset of the full match
+    const prefixRegex = /(?:in |at )([a-zA-Z0-9_\-\.]+\/[a-zA-Z0-9_\-\.\/]*[a-zA-Z0-9_\-\.])/;
+    const line = 'error in src/utils/helper.ts at line 42';
+    const term = mockTerminal([line]);
+    const links = computeLink(1, prefixRegex, term);
+
+    assert.strictEqual(links.length, 1);
+    assert.strictEqual(links[0].text, 'src/utils/helper.ts');
+    // "error in " = 9 chars, path starts at col 10
+    assert.strictEqual(links[0].range.start.x, 10);
+  });
+
+  test('should not misalign when capture group text appears before regex match', () => {
+    // This is the core indexOf bug: when match[0] != match[1] (capture group)
+    // and match[1] text appears earlier in the line, indexOf finds the wrong position.
+    //
+    // Example: regex /(?:in )([a-z\/\.]+)/ matches "in src/a.ts" at index 21,
+    // capture group is "src/a.ts". But indexOf("src/a.ts", 0) finds it at index 6
+    // (the bare occurrence), not at index 24 (inside the regex match).
+    const prefixRegex = /(?:in |at )([a-zA-Z0-9_\-\.]+\/[a-zA-Z0-9_\-\.\/]*[a-zA-Z0-9_\-\.])/;
+    const line = 'Found src/a.ts error in src/a.ts';
+    const term = mockTerminal([line]);
+    const links = computeLink(1, prefixRegex, term);
+
+    // The regex should only match "in src/a.ts" (one match), with
+    // capture group "src/a.ts" at column 25.
+    // BUG: indexOf finds "src/a.ts" at position 6 (the bare occurrence),
+    // causing rex.lastIndex to advance to 14, which then re-matches
+    // "in src/a.ts" at position 21 — producing a DUPLICATE link.
+    // With the fix, there should be exactly 1 link at the correct position.
+    assert.strictEqual(links.length, 1, `Expected 1 link but found ${links.length}: ${JSON.stringify(links.map(l => ({ text: l.text, x: l.range.start.x })))}`);
+    assert.strictEqual(links[0].text, 'src/a.ts');
+    assert.strictEqual(links[0].range.start.x, 25);
+  });
+
+  test('should verify link text matches line content at reported position', () => {
+    // Invariant: for every link, the text at the reported position
+    // must equal the link text. This catches indexOf misalignment.
+    const lines = [
+      'See tabManager.ts docs in src/webview/tabManager.ts for details',
+      'Compare utils/helper.ts with src/utils/helper.ts',
+      'error at src/a.ts and src/b.ts and src/a.ts again',
+    ];
+
+    for (const line of lines) {
+      const term = mockTerminal([line]);
+      const links = computeLink(1, LINK_REGEX, term);
+
+      for (const link of links) {
+        const startIdx = link.range.start.x - 1; // convert to 0-based
+        const extracted = line.substring(startIdx, startIdx + link.text.length);
+        assert.strictEqual(
+          extracted,
+          link.text,
+          `Link "${link.text}" at col ${link.range.start.x} should match ` +
+          `"${extracted}" in line "${line}"`,
+        );
+      }
+    }
+  });
+});

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./out-test",
+    "types": ["mocha", "node"]
+  },
+  "include": ["./src", "./test"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,576 @@
 # yarn lockfile v1
 
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@types/mocha@^10.0.10":
+  version "10.0.10"
+  resolved "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz"
+  integrity sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==
+
+"@types/node@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz"
+  integrity sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==
+  dependencies:
+    undici-types "~7.18.0"
+
 "@xterm/xterm@^6.0.0":
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-6.0.0.tgz#93637b0f2ee3a70718b5746a27c9c506af16745b"
+  resolved "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz"
   integrity sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
+
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
+ansi-styles@^6.1.0:
+  version "6.2.3"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+brace-expansion@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz"
+  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+  dependencies:
+    balanced-match "^1.0.0"
+
+browser-stdout@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
+  integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
+
+camelcase@^6.0.0:
+  version "6.3.0"
+  resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
+
+chalk@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chokidar@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz"
+  integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
+  dependencies:
+    readdirp "^4.0.1"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+cross-spawn@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+debug@^4.3.5:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
+decamelize@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz"
+  integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
+
+diff@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz"
+  integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
+
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+escalade@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+glob@^10.4.5:
+  version "10.5.0"
+  resolved "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+is-path-inside@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
+js-yaml@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  dependencies:
+    argparse "^2.0.1"
+
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
+log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
+
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
+minimatch@^9.0.4, minimatch@^9.0.5:
+  version "9.0.9"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+mocha@^11.7.5:
+  version "11.7.5"
+  resolved "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz"
+  integrity sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==
+  dependencies:
+    browser-stdout "^1.3.1"
+    chokidar "^4.0.1"
+    debug "^4.3.5"
+    diff "^7.0.0"
+    escape-string-regexp "^4.0.0"
+    find-up "^5.0.0"
+    glob "^10.4.5"
+    he "^1.2.0"
+    is-path-inside "^3.0.3"
+    js-yaml "^4.1.0"
+    log-symbols "^4.1.0"
+    minimatch "^9.0.5"
+    ms "^2.1.3"
+    picocolors "^1.1.1"
+    serialize-javascript "^6.0.2"
+    strip-json-comments "^3.1.1"
+    supports-color "^8.1.1"
+    workerpool "^9.2.0"
+    yargs "^17.7.2"
+    yargs-parser "^21.1.1"
+    yargs-unparser "^2.0.0"
+
+ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
+
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
+randombytes@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+  dependencies:
+    safe-buffer "^5.1.0"
+
+readdirp@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz"
+  integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
+
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+safe-buffer@^5.1.0:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+serialize-javascript@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz"
+  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
+  dependencies:
+    randombytes "^2.1.0"
+
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
+
+strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
 
 typescript@^5.7.0:
   version "5.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
+workerpool@^9.2.0:
+  version "9.3.4"
+  resolved "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz"
+  integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs-unparser@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz"
+  integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
+  dependencies:
+    camelcase "^6.0.0"
+    decamelize "^4.0.0"
+    flat "^5.0.2"
+    is-plain-obj "^2.1.0"
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
## Problems

Two bugs in `computeLink` that cause link underlines and click targets to point at the wrong text:

### 1. indexOf re-search finds wrong occurrence

`computeLink` uses `line.indexOf(text, stringIndex + 1)` to find the position of the matched capture group (`match[matchIndex]`) in the line. This fails when the capture group text appears earlier in the line than where the regex actually matched.

**Example:** Given the regex `/(?:in )([a-z\/\.]+)/` and line `"Found src/a.ts error in src/a.ts"`:
- The regex matches `"in src/a.ts"` at index 21, capture group `"src/a.ts"` at index 24
- `indexOf("src/a.ts", 0)` finds position 6 (the bare occurrence), not 24

This causes link ranges pointing to the wrong text and duplicate phantom links.

**Fix:** Derive the capture group position from `match.index`:
```typescript
stringIndex = match.index + match[0].indexOf(text);
```

### 2. stringIndexToBufferPosition drift with empty cells

Empty cells (from cursor moves like `\e[1C`) have `getChars().length === 0` but `getWidth() > 0`. `translateToString` renders them as spaces, consuming a string position. But `stringIndexToBufferPosition` only decremented `stringIndex` by `getChars().length` (0), causing the string-to-cell mapping to drift by 1 for every empty cell.

This produced misaligned link underlines in terminals with styled output (e.g., Claude Code uses wide Unicode characters like ⏺ followed by cursor moves).

**Fix:** When `getChars().length` is 0 and `getWidth() > 0`, decrement `stringIndex` by 1:
```typescript
const charsLen = cell.getChars().length;
const cellWidth = cell.getWidth();
stringIndex -= charsLen > 0 ? charsLen : (cellWidth > 0 ? 1 : 0);
```

## Tests

Added a test suite (the project had none):
- `mocha` + `@types/mocha` as dev dependencies
- `tsconfig-test.json` for test compilation
- Minimal `Terminal` mock + advanced `mockTerminalWithCells` for cell-level simulation
- 10 tests covering both bugs, including regression tests that **fail without the fixes**
- CI workflow (GitHub Actions) + test badge in README

```
npm test
```